### PR TITLE
config.toml: add colour palette

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -39,3 +39,7 @@ url = "https://github.com/bluerobotics/Cockpit?tab=AGPL-3.0-3-ov-file"
 [[extra.license]]
 name = "Cockpit Custom"
 url = "https://github.com/bluerobotics/Cockpit?tab=License-2-ov-file"
+
+[extra.palette]
+primary = "156.71 34.98% 47.65%"
+secondary = "209.17 79.12% 35.69%"


### PR DESCRIPTION
Pre-specifies palette colours for the upcoming theme update.

<img width="1079" alt="Screenshot 2025-01-23 at 2 00 01 am" src="https://github.com/user-attachments/assets/80a5ab9d-4da6-479c-9019-237c279b9ab2" />